### PR TITLE
Add files via upload

### DIFF
--- a/intra_hydrogen_bond.py
+++ b/intra_hydrogen_bond.py
@@ -1,0 +1,51 @@
+import pymol
+import csv
+from pymol import cmd
+
+# Initialize PyMOL
+pymol.finish_launching()
+
+# Load the structures
+print("Loading structures...")
+cmd.load('/Users/myunghyunjeong/Desktop/6lni.pdb', '6lni')
+cmd.load('/Users/myunghyunjeong/Desktop/1qlz.pdb', '1qlz')
+
+# Define hydrogen bond cutoff distance
+hbond_cutoff_distance = 3.5  # Ångströms
+
+# Create a list to store hydrogen bond details
+hbond_details = []
+
+# Select hydrogen bond donors from chain A of 6lni and all acceptors from 1qlz
+cmd.select("6lni_chainA_donors", "chain A and 6lni and donor")
+cmd.select("1qlz_acceptors", "1qlz and acceptor")
+
+# Check if selections are valid
+if cmd.count_atoms("6lni_chainA_donors") == 0 or cmd.count_atoms("1qlz_acceptors") == 0:
+    print("Error: One of the selections is empty.")
+else:
+    # Iterate over each donor and acceptor pair and calculate distances
+    donor_list = cmd.index("6lni_chainA_donors")
+    acceptor_list = cmd.index("1qlz_acceptors")
+
+    for donor in donor_list:
+        for acceptor in acceptor_list:
+            distance = cmd.get_distance(donor, acceptor)
+            if distance <= hbond_cutoff_distance:
+                donor_resi = donor[1]  # Extract donor residue number
+                acceptor_resi = acceptor[1]  # Extract acceptor residue number
+                hbond_details.append([str(donor_resi), str(acceptor_resi), str(distance)])
+
+# Define the path to save the CSV file
+csv_file_path = '/Users/myunghyunjeong/Desktop/PDB_datasets/hbonds.csv'
+
+# Save the hydrogen bond details to a CSV file
+with open(csv_file_path, "w", newline="") as csvfile:
+    writer = csv.writer(csvfile)
+    # Write the header row
+    writer.writerow(["Donor Residue", "Acceptor Residue", "Distance (Å)"])
+    # Write the hydrogen bond details
+    writer.writerows(hbond_details)
+
+# Print a message indicating successful completion
+print("Hydrogen bond details saved to:", csv_file_path)

--- a/intra_hydrogen_bond.py
+++ b/intra_hydrogen_bond.py
@@ -7,8 +7,8 @@ pymol.finish_launching()
 
 # Load the structures
 print("Loading structures...")
-cmd.load('/Users/myunghyunjeong/Desktop/6lni.pdb', '6lni')
-cmd.load('/Users/myunghyunjeong/Desktop/1qlz.pdb', '1qlz')
+cmd.load('/dir/6lni.pdb', '6lni')
+cmd.load('/dir/1qlz.pdb', '1qlz')
 
 # Define hydrogen bond cutoff distance
 hbond_cutoff_distance = 3.5  # Ångströms
@@ -37,7 +37,7 @@ else:
                 hbond_details.append([str(donor_resi), str(acceptor_resi), str(distance)])
 
 # Define the path to save the CSV file
-csv_file_path = '/Users/myunghyunjeong/Desktop/PDB_datasets/hbonds.csv'
+csv_file_path = '/dir/hbonds.csv'
 
 # Save the hydrogen bond details to a CSV file
 with open(csv_file_path, "w", newline="") as csvfile:


### PR DESCRIPTION
## Hydrogen Bond Calculator with PyMOL

This Python script is a Hydrogen Bond Calculator that utilizes the PyMOL library to analyze and compute hydrogen bond details between two PDB (Protein Data Bank) structures. Hydrogen bonds play a crucial role in the interaction and stability of biomolecules, and understanding their presence and strength is essential in the field of structural biology.

### How It Works

Initialization and Structure Loading: The script initializes PyMOL and loads two PDB structures, '6lni' and '1qlz,' provided by the user. These structures are essential for calculating hydrogen bonds.

Hydrogen Bond Cutoff Distance: You can specify the hydrogen bond cutoff distance (in Ångströms) as a parameter. This value determines how close atoms need to be to be considered part of a hydrogen bond.

Selection of Donors and Acceptors: The script selects hydrogen bond donors from 'chain A' of the '6lni' structure and all acceptors from the '1qlz' structure. These selections are critical for identifying potential hydrogen bond interactions.

Calculating Hydrogen Bond Distances: The script iterates over each donor and acceptor pair, calculates the distance between them, and checks if it falls within the specified cutoff distance. If a valid hydrogen bond is detected, the donor residue number, acceptor residue number, and the distance are recorded.

Saving Results: The calculated hydrogen bond details are saved to a .CSV file named hbonds.csv, making it easy to analyze and visualize the results.